### PR TITLE
Add projects data & include; update config/pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,9 @@
 title: Mitch Ricker - Automating.Systems
 description: My personal GitHub Pages portfolio
 url: https://Automating.Systems
+###############################
+github_name: MitchRicker
 github: https://github.com/mitchricker
+
+kofi_name: MitchRicker
+kofi: https://ko-fi.com/mitchricker

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,17 @@
+- name: PSUserMigrate
+  teaser: "PSUserMigrate is a PowerShell tool that automates user environment migration, making workstation refreshes, break/fix scenarios, and user migrations faster and safer."
+  repo: "PSUserMigrate"
+  details: |
+    PSUserMigrate captures and restores user settings including browsers, Wi-Fi profiles, VPNs, 
+    Outlook signatures, mapped drives, printers, and Sticky Notes, on the same or another machine.
+    It supports selective component capture, optional AES-256 ZIP encryption via 7-Zip, automatic
+    7-Zip installation if needed, and generates a migration manifest for auditing. Designed for 
+    helpdesk and field use, it reduces operational overhead while ensuring consistent, recoverable migrations.
+
+- name: SecureWinRM
+  teaser: "SecureWinRM is a PowerShell module that automates hardened WinRM configuration."
+  repo: "SecureWinRM"
+  details: |
+    SecureWinRM configures Windows Remote Management with opinionated security defaults,
+    including HTTPS-only transport and strong authentication. It prevents insecure WinRM
+    configurations from being introduced during automation or system setup.

--- a/_includes/project.html
+++ b/_includes/project.html
@@ -1,0 +1,26 @@
+<section class="project">
+  <h2>{{ include.name }}</h2>
+
+  <p class="project-teaser">{{ include.teaser }}</p>
+
+  <div class="project-buttons">
+    {% if include.details %}
+  <button class="project-toggle"
+          onclick="let details=this.closest('.project').querySelector('.project-details'); details.classList.toggle('hidden'); this.textContent=(details.classList.contains('hidden')?'Show Details':'Hide Details');">
+    Show Details
+  </button>
+{% endif %}
+
+    <a href="{{ site.github }}/{{ include.repo }}" target="_blank"
+       rel="noopener noreferrer" class="project-toggle">
+      View on GitHub
+    </a>
+  </div>
+
+  {% if include.details %}
+    <div class="project-details hidden">
+      <p>{{ include.details }}</p>
+    </div>
+  {% endif %}
+</section>
+<hr>

--- a/about.html
+++ b/about.html
@@ -28,10 +28,11 @@ description: About Me - Automating.Systems
   </p>
 
   <p>
-    Feel free to drop me a line. I'm relatively sociable (for an engineer) and will try my best to reply. There has been a recent uptick in spam, so I apologize in advance if anything gets missed.
+    Feel free to drop me a line; I'm relatively sociable (for an engineer) and will try my best to reply. There has been a recent uptick in spam, so I apologize in advance if anything gets missed.
   </p>
 
   <p>
-    GitHub: <a href="{{ site.github }}">MitchRicker</a>
+    GitHub: <a href="{{ site.github }}" target="_blank" rel="noopener noreferrer">{{ site.github_name }}</a><br>
+    Ko-Fi: <a href="{{ site.kofi }}" target="_blank" rel="noopener noreferrer">{{ site.kofi_name }}</a>
   </p>
 </section>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: Mitch Ricker
 <section>
   <h1>Automating.Systems</h1>
   <p>
-    I design, operate, and automate systems and network infrastructure, with a focus on reducing manual work and improving reliability.
+    Hello there, my name's Mitch. I design, operate, and automate systems and network infrastructure, with a focus on reducing manual work and improving reliability.
   </p>
   <p>
     My day-to-day work revolves around automation using <code>bash</code>, <code>pwsh</code>, and <code>python</code>.
@@ -28,6 +28,8 @@ title: Mitch Ricker
 <section>
   <h2>About This Site</h2>
   <p>
-    This site is a collection of professional projects and experiments related to systems, networking, and automation.
+    This site is a collection of professional projects and experiments related to systems, networking and automation.
+    All opinions expressed here are my own and do not reflect the views of any employer, past, present or future.
+    If you choose to use any of the software showcased here: please review the license information carefully.
   </p>
 </section>

--- a/projects.html
+++ b/projects.html
@@ -3,88 +3,35 @@ layout: default
 title: Projects
 description: Projects - Automating.Systems
 ---
-    <section>
-      <h1>Projects</h1>
+<section>
+  <h1>Projects</h1>
 
-      <p>
-        This page contains a selection of personal and professional projects
-        focused on systems, network, and infrastructure automation.
-        Most of these tools were built to solve real operational problems
-        and improve reliability or efficiency.
-      </p>
+  <p>
+    This page contains a selection of personal and professional projects
+    focused on systems, network, and infrastructure automation.
+    Most of these tools were built to solve real operational problems
+    and improve reliability or efficiency.
+  </p>
 
-      <p>
-        The projects here range from small, focused utilities to larger
-        automation workflows, primarily written in Bash, PowerShell, and Python.
-      </p>
+  <p>
+    The projects here range from small, focused utilities to larger
+    automation workflows, primarily written in Bash, PowerShell, and Python.
+  </p>
 
-      <p>
-        If you find any of this software useful and would like to support
-        continued development, you can leave an optional tip on <strong>
-        <a href="https://ko-fi.com/mitchricker" target="_blank" rel="noopener noreferrer">
-          Ko-fi</a></strong>.
-      </p>
-    </section>
-    <hr>
+  <p>
+    If you find any of this software useful and would like to support
+    continued development, you can leave an optional tip on <strong>
+    <a href="{{ site.kofi }}" target="_blank" rel="noopener noreferrer">
+      Ko-fi</a></strong>.
+  </p>
+</section>
 
-    <section class="project">
-      <h2>PSUserMigrate</h2>
+<!-- Jekyll is pretty neat, huh? -->
 
-      <p class="project-teaser">
-        <strong>PSUserMigrate</strong> is a PowerShell tool that automates user environment migration,
-        making workstation refreshes, break/fix scenarios, and user migrations faster and safer.
-      </p>
-
-      <div class="project-buttons">
-        <!-- Show details toggle -->
-        <button class="project-toggle" onclick="this.closest('.project').querySelector('.project-details').classList.toggle('hidden');">
-          Show Details
-        </button>
-
-        <!-- GitHub repo button -->
-        <a href="https://github.com/mitchricker/PSUserMigrate" target="_blank" rel="noopener noreferrer" class="project-toggle">
-          View on GitHub
-        </a>
-      </div>
-
-      <!-- Hidden detailed description -->
-      <div class="project-details hidden">
-        <p>
-          PSUserMigrate captures and restores user settings including browsers, Wi-Fi profiles, VPNs, 
-          Outlook signatures, mapped drives, printers, and Sticky Notes, on the same or another machine.
-          It supports selective component capture, optional AES-256 ZIP encryption via 7-Zip, automatic
-          7-Zip installation if needed, and generates a migration manifest for auditing. Designed for 
-          helpdesk and field use, it reduces operational overhead while ensuring consistent, recoverable migrations.                                configurations from being introduced during automation or system setup.
-        </p>
-      </div>
-    </section>
-    <hr>
-    <section class="project">
-      <h2>SecureWinRM</h2>
-
-      <p class="project-teaser">
-        <strong>SecureWinRM</strong> is a PowerShell module that automates hardened WinRM configuration.
-      </p>
-
-      <div class="project-buttons">
-        <!-- Show details toggle -->
-        <button class="project-toggle" onclick="this.closest('.project').querySelector('.project-details').classList.toggle('hidden');">
-          Show Details
-        </button>
-
-        <!-- GitHub repo button -->
-        <a href="https://github.com/mitchricker/SecureWinRM" target="_blank" rel="noopener noreferrer" class="project-toggle">
-          View on GitHub
-        </a>
-      </div>
-
-      <!-- Hidden detailed description -->
-      <div class="project-details hidden">
-        <p>
-          SecureWinRM configures Windows Remote Management with opinionated security defaults, including HTTPS
-          only transport and strong authentication. The goal is to remove ambiguity and prevent insecure WinRM
-          configurations from being introduced during automation or system setup.
-        </p>
-      </div>
-    </section>
-    <hr>
+{% for project in site.data.projects %}
+  {% include project.html
+      name=project.name
+      teaser=project.teaser
+      repo=project.repo
+      details=project.details %}
+{% endfor %}


### PR DESCRIPTION
Introduce a data-driven projects system: add _data/projects.yml and a reusable _includes/project.html to render project entries with toggled details and GitHub links. Update projects.html to loop over site.data.projects and use the new include. Update _config.yml with github_name and Ko‑fi fields (kofi_name, kofi) and adjust about.html and index.html to surface the new site variables and a brief disclaimer/voice edits. Minor markup and link target/rel improvements for external links.